### PR TITLE
@since magento 1.8.1.0 added formkey to login form

### DIFF
--- a/app/design/frontend/waterlee-boilerplate/default/template/persistent/customer/form/login.phtml
+++ b/app/design/frontend/waterlee-boilerplate/default/template/persistent/customer/form/login.phtml
@@ -38,6 +38,7 @@
     </div>
     <?php echo $this->getMessagesBlock()->getGroupedHtml() ?>
     <form action="<?php echo $this->getPostActionUrl() ?>" method="post" id="login-form">
+        <?php echo $this->getBlockHtml('formkey'); ?>
         <div class="col2-set row">
             <div class="col-1 new-users columns large-7">
                 <div class="content">


### PR DESCRIPTION
Login form is not working. I found 'formkey' is missing, @since magento 1.8.1.0 we have to add it to forms.

as per this discussion
http://magento.stackexchange.com/questions/11871/customer-cant-log-in?answertab=active#tab-top
