### PR TITLE
Missing dash in "site nav"

### DIFF
--- a/app/design/frontend/waterlee-boilerplate/default/template/page/html/header.phtml
+++ b/app/design/frontend/waterlee-boilerplate/default/template/page/html/header.phtml
@@ -42,7 +42,7 @@
 
 <header class="site-header">
     <div class="site-header-content row">
-            <div class="site nav columns small-12 costum-column show-for-small-only">
+            <div class="site-nav columns small-12 costum-column show-for-small-only">
                 <nav class="top-bar" data-topbar>
                     <ul class="title-area">
                         <li class="name">                                                    


### PR DESCRIPTION
Looks like you were missing the - in site nav. This cause the .site-nav styles to not show
