### PR TITLE
Remove hardcoded URLs from css

### DIFF
--- a/skin/frontend/waterlee-boilerplate/default/scss/custom/_checkout.scss
+++ b/skin/frontend/waterlee-boilerplate/default/scss/custom/_checkout.scss
@@ -289,7 +289,7 @@ Cart styling
 /* Remember Me Popup ===================================================================== */
 
 .validate-select, .validate-select:hover {
-  background: white url("http://waterlee.jakesharp.co/demo/skin/frontend/waterlee-boilerplate/default/images/arrow.png") no-repeat scroll 98% center;
+  background: white url("../images/arrow.png") no-repeat scroll 98% center;
 }
 .checkout-types {
   margin-bottom: 0rem;

--- a/skin/frontend/waterlee-boilerplate/default/scss/custom/_product-page.scss
+++ b/skin/frontend/waterlee-boilerplate/default/scss/custom/_product-page.scss
@@ -62,7 +62,7 @@
   margin-bottom: 0rem;
 }
 .required-entry-conf, .required-entry-conf:hover {
-  background: white url("http://waterlee.jakesharp.co/demo/skin/frontend/waterlee-boilerplate/default/images/arrow.png") no-repeat scroll 98% center;
+  background: white url("../images/arrow.png") no-repeat scroll 98% center;
 }
 .price-box {
   margin-left: 0.05rem !important;
@@ -111,7 +111,7 @@ display: none;
   transform: translateY(40%);
 }
 .bundle-option-select, .bundle-option-select:hover {
-  background: white url("http://waterlee.jakesharp.co/demo/skin/frontend/waterlee-boilerplate/default/images/arrow.png") no-repeat scroll 98% center;
+  background: white url("../images/arrow.png") no-repeat scroll 98% center;
 }
 .downloadable-links {
   background-color: #fff;


### PR DESCRIPTION
fixes https://github.com/zeljkoprsa/waterlee-boilerplate/issues/62

tonight's MVP:

``` bash
ag --sass -Q "http://waterlee.jakesharp.co/demo/skin/frontend/waterlee-boilerplate/default" -l | xargs gsed -i -E 's,http://waterlee.jakesharp.co/demo/skin/frontend/waterlee-boilerplate/default,..,g'
```

This is tested working on my install. `arrow.png` is already included in the theme even.
