### PR TITLE
Update foundation.equalizer.js

### DIFF
--- a/skin/frontend/waterlee-boilerplate/default/src_js/foundation.equalizer.js
+++ b/skin/frontend/waterlee-boilerplate/default/src_js/foundation.equalizer.js
@@ -10,7 +10,7 @@
       use_tallest: true,
       before_height_change: $.noop,
       after_height_change: $.noop,
-      equalize_on_stack: false
+      equalize_on_stack: true
     },
 
     init : function (scope, method, options) {


### PR DESCRIPTION
By setting equalize_on_stack true, when products in grid view get stacked (more than one row) their containers will be equal heights too.